### PR TITLE
Add support for Tree Style Tab

### DIFF
--- a/xpi/content/options.xul
+++ b/xpi/content/options.xul
@@ -125,6 +125,7 @@
 							<menupopup>
 								<menuitem value="right" label="&superdrag.newtab.pos.right;" />
 								<menuitem value="rightmost" label="&superdrag.newtab.pos.rightmost;" />
+								<menuitem value="child" label="&superdrag.newtab.pos.child;" />
 							</menupopup>
 						</menulist>
 					</row>
@@ -132,7 +133,7 @@
 						<vbox pack="center">
 							<label value="&superdrag.newtab.onleft.for.foreground;" />
 						</vbox>
-						<menulist preference="pref-newtab-onleft-for-foreground">
+						<menulist id="menu-newtab-onleft-for-foreground" preference="pref-newtab-onleft-for-foreground">
 							<menupopup>
 								<menuitem value="true" label="&superdrag.newtab.onleft.yes;" />
 								<menuitem value="false" label="&superdrag.newtab.onleft.no;" />
@@ -172,6 +173,18 @@
 					}
 				}
 			}
+
+			var prefPos = document.getElementById('pref-newtab-pos');
+			var menuLeft = document.getElementById('menu-newtab-onleft-for-foreground');
+			var onMenuLeftChange = function() {
+				if(prefPos.value === 'child') {
+					menuLeft.disabled = true;
+				} else {
+					menuLeft.disabled = false;
+				}
+			};
+			prefPos.addEventListener('change', onMenuLeftChange, false);
+			onMenuLeftChange();
 		}, false);
 
 		window.addEventListener('unload', function() {

--- a/xpi/locale/en-US/strings.dtd
+++ b/xpi/locale/en-US/strings.dtd
@@ -35,6 +35,7 @@
 <!ENTITY superdrag.newtab.pos "Where to put the new tab">
 <!ENTITY superdrag.newtab.pos.right "Right to current">
 <!ENTITY superdrag.newtab.pos.rightmost "Right most">
+<!ENTITY superdrag.newtab.pos.child "As child (Tree Style Tab)">
 <!ENTITY superdrag.newtab.onleft.for.foreground "Where to put foreground tab">
 <!ENTITY superdrag.newtab.onleft.yes "Left to current tab">
 <!ENTITY superdrag.newtab.onleft.no "Same as above">

--- a/xpi/modules/superdrag.js
+++ b/xpi/modules/superdrag.js
@@ -523,15 +523,21 @@ var SuperDrag = new function() {
 				inBackground: true,
 				relatedToCurrent: true
 			};
+			let pos = Services.prefs.getCharPref('extensions.superdrag.newtab.pos');
+			let left = Services.prefs.getBoolPref('extensions.superdrag.newtab.onleft.for.foreground');
+			// support for "Tree Style Tab"
+			if ('TreeStyleTabService' in mw && pos === 'right' &&
+			   (how !== 'foreground' || !left)) {
+				mw.TreeStyleTabService.readyToOpenChildTab(tb.selectedTab);
+			}
 			let tab = tb.loadOneTab(url, param);
 			let needMove = false;
 			let moveTo = tb.tabs.length - 1;
-			let pos = Services.prefs.getCharPref('extensions.superdrag.newtab.pos');
 			if (pos === 'right') {
 				moveTo = i + 1;
 			}
 			if (how === 'foreground') {
-				if (Services.prefs.getBoolPref('extensions.superdrag.newtab.onleft.for.foreground')) {
+				if (left) {
 					moveTo = i;
 					needMove = true;
 				}

--- a/xpi/modules/superdrag.js
+++ b/xpi/modules/superdrag.js
@@ -526,8 +526,7 @@ var SuperDrag = new function() {
 			let pos = Services.prefs.getCharPref('extensions.superdrag.newtab.pos');
 			let left = Services.prefs.getBoolPref('extensions.superdrag.newtab.onleft.for.foreground');
 			// support for "Tree Style Tab"
-			if ('TreeStyleTabService' in mw && pos === 'right' &&
-			   (how !== 'foreground' || !left)) {
+			if ('TreeStyleTabService' in mw && pos === 'child') {
 				mw.TreeStyleTabService.readyToOpenChildTab(tb.selectedTab);
 			}
 			let tab = tb.loadOneTab(url, param);
@@ -537,7 +536,7 @@ var SuperDrag = new function() {
 				moveTo = i + 1;
 			}
 			if (how === 'foreground') {
-				if (left) {
+				if (left && pos !== 'child') {
 					moveTo = i;
 					needMove = true;
 				}


### PR DESCRIPTION
These two commits add support for opening tabs as child of the current one if [Tree Style Tab](https://addons.mozilla.org/de/firefox/addon/tree-style-tab/) is installed.
- The first commit adds the basic support and can be merged alone. In this case, tabs are opened as child tabs if the position setting is set to _right_.
- The second commit adds a new option to explicitly enable the behaviour. (_right_ stays the default)

The zh-CN locale is not included because I do not speak Chinese.
